### PR TITLE
Decouple USB writes from memory writes

### DIFF
--- a/common/memory_wrapper.hpp
+++ b/common/memory_wrapper.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <sys/un.h>
+
+struct MemoryWrapper
+{
+public:
+    MemoryWrapper(void *mem, size_t memSize, void *exifMem, size_t exifMemSize)
+        : memSize(memSize), exifMemSize(exifMemSize)
+    {
+        this->mem = malloc(memSize);
+        if (this->mem == nullptr)
+        {
+            throw std::bad_alloc();
+        }
+        this->exifMem = malloc(exifMemSize);
+        if (this->exifMem == nullptr)
+        {
+            this->~MemoryWrapper();
+            throw std::bad_alloc();
+        }
+        memcpy(this->mem, mem, memSize);
+        memcpy(this->exifMem, exifMem, exifMemSize);
+    }
+    ~MemoryWrapper()
+    {
+        free(this->mem);
+        free(this->exifMem);
+    }
+
+    MemoryWrapper(MemoryWrapper &&other)
+    {
+        this->operator=(std::move(other));
+    }
+
+    MemoryWrapper &operator=(MemoryWrapper &&other)
+    {
+        this->mem = other.mem;
+        this->memSize = other.memSize;
+        this->exifMem = other.exifMem;
+        this->exifMemSize = other.exifMemSize;
+
+        other.mem = nullptr;
+        other.exifMem = nullptr;
+        return *this;
+    }
+
+    MemoryWrapper(const MemoryWrapper &) = delete;
+    MemoryWrapper &operator=(const MemoryWrapper &) = delete;
+
+    void *mem;
+    size_t memSize;
+    void *exifMem;
+    size_t exifMemSize;
+};

--- a/common/memory_wrapper.hpp
+++ b/common/memory_wrapper.hpp
@@ -5,27 +5,20 @@
 struct MemoryWrapper
 {
 public:
-    MemoryWrapper(void *mem, size_t memSize, void *exifMem, size_t exifMemSize)
-        : memSize(memSize), exifMemSize(exifMemSize)
+    MemoryWrapper(void *mem, size_t size)
+        : size(size)
     {
-        this->mem = malloc(memSize);
+        this->mem = malloc(size);
         if (this->mem == nullptr)
         {
             throw std::bad_alloc();
         }
-        this->exifMem = malloc(exifMemSize);
-        if (this->exifMem == nullptr)
-        {
-            this->~MemoryWrapper();
-            throw std::bad_alloc();
-        }
-        memcpy(this->mem, mem, memSize);
-        memcpy(this->exifMem, exifMem, exifMemSize);
+        memcpy(this->mem, mem, size);
     }
+
     ~MemoryWrapper()
     {
         free(this->mem);
-        free(this->exifMem);
     }
 
     MemoryWrapper(MemoryWrapper &&other)
@@ -36,12 +29,9 @@ public:
     MemoryWrapper &operator=(MemoryWrapper &&other)
     {
         this->mem = other.mem;
-        this->memSize = other.memSize;
-        this->exifMem = other.exifMem;
-        this->exifMemSize = other.exifMemSize;
+        this->size = other.size;
 
         other.mem = nullptr;
-        other.exifMem = nullptr;
         return *this;
     }
 
@@ -49,7 +39,5 @@ public:
     MemoryWrapper &operator=(const MemoryWrapper &) = delete;
 
     void *mem;
-    size_t memSize;
-    void *exifMem;
-    size_t exifMemSize;
+    size_t size;
 };

--- a/common/message_queue.hpp
+++ b/common/message_queue.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+
+template <typename T>
+class MessageQueue
+{
+public:
+    template <typename U>
+    void Post(U &&msg)
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        queue_.push(std::forward<U>(msg));
+        cond_.notify_one();
+    }
+    T Wait()
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cond_.wait(lock, [this] { return !queue_.empty(); });
+        T msg = std::move(queue_.front());
+        queue_.pop();
+        return msg;
+    }
+    void Clear()
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        queue_ = {};
+    }
+
+private:
+    std::queue<T> queue_;
+    std::mutex mutex_;
+    std::condition_variable cond_;
+};

--- a/common/semaphore.hpp
+++ b/common/semaphore.hpp
@@ -5,31 +5,12 @@
 
 class Semaphore
 {
-    std::mutex mutex_;
-    std::condition_variable condition_;
-    unsigned long count_ = 0; // Initialized as locked.
-
 public:
     void release()
     {
-        std::lock_guard<decltype(mutex_)> lock(mutex_);
+        std::lock_guard<std::mutex> lock(mutex_);
         ++count_;
         condition_.notify_one();
-    }
-
-    bool acquire()
-    {
-        std::unique_lock<decltype(mutex_)> lock(mutex_);
-        // while(!count_) // Handle spurious wake-ups.
-        //     condition_.wait(lock);
-        using namespace std::chrono_literals;
-        condition_.wait_for(lock, 1ms);
-        if (!count_)
-        {
-            return false;
-        }
-        --count_;
-        return true;
     }
 
     bool try_acquire()
@@ -42,4 +23,9 @@ public:
         }
         return false;
     }
+
+private:
+    std::mutex mutex_;
+    std::condition_variable condition_;
+    unsigned long count_ = 0; // Initialized as locked.
 };

--- a/common/semaphore.hpp
+++ b/common/semaphore.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <mutex>
-#include <condition_variable>
 
 class Semaphore
 {

--- a/common/semaphore.hpp
+++ b/common/semaphore.hpp
@@ -15,7 +15,7 @@ public:
 
     bool try_acquire()
     {
-        std::lock_guard<decltype(mutex_)> lock(mutex_);
+        std::lock_guard<std::mutex> lock(mutex_);
         if (count_)
         {
             --count_;

--- a/common/semaphore.hpp
+++ b/common/semaphore.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <mutex>
+#include <condition_variable>
+
+class Semaphore
+{
+    std::mutex mutex_;
+    std::condition_variable condition_;
+    unsigned long count_ = 0; // Initialized as locked.
+
+public:
+    void release()
+    {
+        std::lock_guard<decltype(mutex_)> lock(mutex_);
+        ++count_;
+        condition_.notify_one();
+    }
+
+    bool acquire()
+    {
+        std::unique_lock<decltype(mutex_)> lock(mutex_);
+        // while(!count_) // Handle spurious wake-ups.
+        //     condition_.wait(lock);
+        using namespace std::chrono_literals;
+        condition_.wait_for(lock, 1ms);
+        if (!count_)
+        {
+            return false;
+        }
+        --count_;
+        return true;
+    }
+
+    bool try_acquire()
+    {
+        std::lock_guard<decltype(mutex_)> lock(mutex_);
+        if (count_)
+        {
+            --count_;
+            return true;
+        }
+        return false;
+    }
+};

--- a/common/semaphore.hpp
+++ b/common/semaphore.hpp
@@ -10,7 +10,6 @@ public:
     {
         std::lock_guard<std::mutex> lock(mutex_);
         ++count_;
-        condition_.notify_one();
     }
 
     bool try_acquire()
@@ -26,6 +25,5 @@ public:
 
 private:
     std::mutex mutex_;
-    std::condition_variable condition_;
     unsigned long count_ = 0; // Initialized as locked.
 };

--- a/core/libcamera_app.hpp
+++ b/core/libcamera_app.hpp
@@ -30,6 +30,7 @@
 
 #include "core/completed_request.hpp"
 #include "core/post_processor.hpp"
+#include "../common/message_queue.hpp"
 
 struct Options;
 
@@ -122,37 +123,6 @@ protected:
 	std::unique_ptr<Options> options_;
 
 private:
-	template <typename T>
-	class MessageQueue
-	{
-	public:
-		template <typename U>
-		void Post(U &&msg)
-		{
-			std::unique_lock<std::mutex> lock(mutex_);
-			queue_.push(std::forward<U>(msg));
-			cond_.notify_one();
-		}
-		T Wait()
-		{
-			std::unique_lock<std::mutex> lock(mutex_);
-			cond_.wait(lock, [this] { return !queue_.empty(); });
-			T msg = std::move(queue_.front());
-			queue_.pop();
-			return msg;
-		}
-		void Clear()
-		{
-			std::unique_lock<std::mutex> lock(mutex_);
-			queue_ = {};
-		}
-
-	private:
-		std::queue<T> queue_;
-		std::mutex mutex_;
-		std::condition_variable cond_;
-	};
-	
 	void setupCapture();
 	void makeRequests();
 	void queueRequest(CompletedRequest *completed_request);

--- a/network/file_output.cpp
+++ b/network/file_output.cpp
@@ -75,6 +75,9 @@ void FileOutput::usbThreadLoop() {
         waitForUSB_.release();
         Work w = std::move(filesToTransfer_.Wait());
 
+        const MemoryWrapper &m = w.memWrapper;
+        std::cout << "Stats: " << m.mem << " " << m.memSize << " " << m.exifMem << " " << m.exifMemSize << std::endl;
+
         if (!options_->skip_4k) {
             const MemoryWrapper &mw = w.memWrapper;
             wrapAndWrite(mw.mem, w.filePath, mw.memSize, mw.exifMem, mw.exifMemSize, 1);

--- a/network/file_output.cpp
+++ b/network/file_output.cpp
@@ -212,16 +212,19 @@ void FileOutput::outputBuffer(void *mem,
         void *copy_of_exifMem = malloc(exifSize);
         memcpy(copy_of_mem, mem, size);
         memcpy(copy_of_exifMem, exifMem, exifSize);
-        waitForUSB_.acquire();
-        filesToTransfer_.Post(Work {
-            tv,
-            secFileName,
-            copy_of_mem,
-            size,
-            copy_of_exifMem,
-            exifSize,
-            1,
-        });
+        bool available = waitForUSB_.acquire();
+
+        if (available) {
+            filesToTransfer_.Post(Work {
+                tv,
+                secFileName,
+                copy_of_mem,
+                size,
+                copy_of_exifMem,
+                exifSize,
+                1,
+            });
+        }
     }
 
     if (!dir2K_.empty() && !options_->skip_2k) {

--- a/network/file_output.cpp
+++ b/network/file_output.cpp
@@ -185,21 +185,17 @@ void FileOutput::outputBuffer(void *mem,
                 if (!options_->skip_4k)
                 {
                     filesToTransfer_.Post(UsbThreadWork{
-                        tv,
                         secFileName,
                         MemoryWrapper(mem, size), // Make a copy of mem and exifMem
                         MemoryWrapper(exifMem, exifSize),
-                        1,
                     });
                 }
                 else if (!options_->skip_2k)
                 {
                     filesToTransfer_.Post(UsbThreadWork{
-                        tv,
                         secFileName,
                         MemoryWrapper(prevMem, prevSize),
                         MemoryWrapper(exifMem, exifSize),
-                        1,
                     });
                 }
             }

--- a/network/file_output.cpp
+++ b/network/file_output.cpp
@@ -63,9 +63,18 @@ FileOutput::FileOutput(VideoOptions const *options) : Output(options) {
     if (!dirUSB_.empty()) {
         collectExistingFilenames();
     }
+
+    usbThread_ = std::thread(std::bind(&FileOutput::usbFunction, this)); 
 }
 
 FileOutput::~FileOutput() {
+}
+
+void FileOutput::usbFunction() {
+    while (1) {
+        sleep(1);
+        std::cerr << "Hello" << std::endl;
+    }
 }
 
 void FileOutput::collectExistingFilenames() {

--- a/network/file_output.cpp
+++ b/network/file_output.cpp
@@ -177,7 +177,7 @@ void FileOutput::outputBuffer(void *mem,
                                                         prefix_, tv.tv_sec,
                                                         tv.tv_usec, postfix_);
 
-        bool usbThreadAvailable = waitForUSB_.acquire();
+        bool usbThreadAvailable = waitForUSB_.try_acquire();
         if (usbThreadAvailable)
         {
             try

--- a/network/file_output.cpp
+++ b/network/file_output.cpp
@@ -205,7 +205,7 @@ void FileOutput::outputBuffer(void *mem,
                     1,
                 });
             }
-        } catch(std::bad_alloc err) {
+        } catch(std::bad_alloc const&) {
             std::cerr << "Failed to allocate space for USB write" << std::endl;
         }
     }

--- a/network/file_output.hpp
+++ b/network/file_output.hpp
@@ -72,12 +72,25 @@ struct MemoryWrapper {
             free(this->exifMem);
         }
 
+        MemoryWrapper(MemoryWrapper&& other) 
+        {
+            this->operator=(std::move(other));
+        }
+
+        MemoryWrapper& operator=(MemoryWrapper&& other) 
+        {
+            this->mem = other.mem;
+            this->memSize = other.memSize;
+            this->exifMem = other.exifMem;
+            this->exifMemSize = other.exifMemSize;
+
+            other.mem = nullptr;
+            other.exifMem = nullptr;
+            return *this;
+        }
+
         MemoryWrapper(const MemoryWrapper&) = delete;
         MemoryWrapper& operator=(const MemoryWrapper&) = delete;
-
-        MemoryWrapper(MemoryWrapper&&) = default;
-        MemoryWrapper& operator=(MemoryWrapper&&) = default;
-
 
         void *mem;
         size_t memSize;

--- a/network/file_output.hpp
+++ b/network/file_output.hpp
@@ -72,6 +72,13 @@ struct MemoryWrapper {
             free(this->exifMem);
         }
 
+        MemoryWrapper(const MemoryWrapper&) = delete;
+        MemoryWrapper& operator=(const MemoryWrapper&) = delete;
+
+        MemoryWrapper(MemoryWrapper&&) = default;
+        MemoryWrapper& operator=(MemoryWrapper&&) = default;
+
+
         void *mem;
         size_t memSize;
         void *exifMem;

--- a/network/file_output.hpp
+++ b/network/file_output.hpp
@@ -59,10 +59,12 @@ struct Work {
     int index;
 };
 
+using namespace std::chrono_literals;
 class Semaphore {
     std::mutex mutex_;
     std::condition_variable condition_;
     unsigned long count_ = 0; // Initialized as locked.
+
 
 public:
     void release() {
@@ -71,11 +73,16 @@ public:
         condition_.notify_one();
     }
 
-    void acquire() {
+    bool acquire() {
         std::unique_lock<decltype(mutex_)> lock(mutex_);
-        while(!count_) // Handle spurious wake-ups.
-            condition_.wait(lock);
+        // while(!count_) // Handle spurious wake-ups.
+        //     condition_.wait(lock);
+        condition_.wait_for(lock, 1ms);
+        if (!count_) {
+            return false; 
+        }
         --count_;
+        return true;
     }
 
     bool try_acquire() {

--- a/network/file_output.hpp
+++ b/network/file_output.hpp
@@ -15,6 +15,78 @@
 #include <mutex>
 #include <thread>
 #include "output.hpp"
+#include <condition_variable>
+#include <semaphore>
+
+template <typename T>
+class MessageQueue
+{
+public:
+    template <typename U>
+    void Post(U &&msg)
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        queue_.push(std::forward<U>(msg));
+        cond_.notify_one();
+    }
+    T Wait()
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cond_.wait(lock, [this] { return !queue_.empty(); });
+        T msg = std::move(queue_.front());
+        queue_.pop();
+        return msg;
+    }
+    void Clear()
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        queue_ = {};
+    }
+
+private:
+    std::queue<T> queue_;
+    std::mutex mutex_;
+    std::condition_variable cond_;
+};
+
+struct Work {
+    timeval time;
+    std::filesystem::path filePath;
+    void *mem;
+    size_t size;
+    void *exifMem;
+    size_t exifSize;
+    int index;
+};
+
+class Semaphore {
+    std::mutex mutex_;
+    std::condition_variable condition_;
+    unsigned long count_ = 0; // Initialized as locked.
+
+public:
+    void release() {
+        std::lock_guard<decltype(mutex_)> lock(mutex_);
+        ++count_;
+        condition_.notify_one();
+    }
+
+    void acquire() {
+        std::unique_lock<decltype(mutex_)> lock(mutex_);
+        while(!count_) // Handle spurious wake-ups.
+            condition_.wait(lock);
+        --count_;
+    }
+
+    bool try_acquire() {
+        std::lock_guard<decltype(mutex_)> lock(mutex_);
+        if(count_) {
+            --count_;
+            return true;
+        }
+        return false;
+    }
+};
 
 class FileOutput : public Output
 {
@@ -62,7 +134,8 @@ private:
     std::deque<std::filesystem::path> filesStoredOnUSB_;
     uint32_t minUSBFreeSpace_ = 0;
     uint32_t maxUSBFiles_ = 0;
+    MessageQueue<Work> filesToTransfer_;
 
     std::thread usbThread_;
-
+    Semaphore waitForUSB_;
 };

--- a/network/file_output.hpp
+++ b/network/file_output.hpp
@@ -13,6 +13,7 @@
 
 #include <queue>
 #include <mutex>
+#include <thread>
 #include "output.hpp"
 
 class FileOutput : public Output
@@ -24,6 +25,8 @@ public:
     void checkGPSLock();
 
 protected:
+
+    void usbFunction();
 
     void outputBuffer(void *mem,
                       size_t size,
@@ -59,5 +62,7 @@ private:
     std::deque<std::filesystem::path> filesStoredOnUSB_;
     uint32_t minUSBFreeSpace_ = 0;
     uint32_t maxUSBFiles_ = 0;
+
+    std::thread usbThread_;
 
 };

--- a/network/file_output.hpp
+++ b/network/file_output.hpp
@@ -21,11 +21,9 @@
 
 struct UsbThreadWork
 {
-    timeval time;
     std::filesystem::path filePath;
     MemoryWrapper memWrapper;
     MemoryWrapper exIfWrapper;
-    int index;
 };
 
 class FileOutput : public Output

--- a/network/file_output.hpp
+++ b/network/file_output.hpp
@@ -19,11 +19,12 @@
 #include "../common/semaphore.hpp"
 #include "../common/memory_wrapper.hpp"
 
-struct Work
+struct UsbThreadWork
 {
     timeval time;
     std::filesystem::path filePath;
     MemoryWrapper memWrapper;
+    MemoryWrapper exIfWrapper;
     int index;
 };
 
@@ -71,7 +72,7 @@ private:
     std::deque<std::filesystem::path> filesStoredOnUSB_;
     uint32_t minUSBFreeSpace_ = 0;
     uint32_t maxUSBFiles_ = 0;
-    MessageQueue<Work> filesToTransfer_;
+    MessageQueue<UsbThreadWork> filesToTransfer_;
 
     std::thread usbThread_;
     Semaphore waitForUSB_;


### PR DESCRIPTION
Ticket: #9 

USB writes are now handled on a separate thread.  The original write thread will submit a write task to the USB write thread if the USB write thread is available.  

USB write tasks are not buffered. If the USB thread is not available, the image write will be skipped.